### PR TITLE
Support for nodeSelector spec

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -886,6 +886,27 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				nil,
 				nil,
 			),
+			"nodeSelector": schema.NewPropertySchema(
+				schema.NewMapSchema(
+					labelName,
+					labelValue,
+					nil,
+					nil,
+				),
+				schema.NewDisplayValue(
+					schema.PointerTo("Labels"),
+					schema.PointerTo(
+						"Node labels you want the target node to have.",
+					),
+					nil,
+				),
+				false,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
 			"pluginContainer": schema.NewPropertySchema(
 				schema.NewStructMappedObjectSchema[v1.Container](
 					"Plugin container",


### PR DESCRIPTION
## Changes introduced with this PR

Support for the **nodeSelector** feature of the k8s API.

**nodeSelector** is the simplest recommended form of node selection constraint. You can add the **nodeSelector** field to your Pod specification and specify the [node labels](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels) you want the target node to have.

Kubernetes will only schedule the Pod onto nodes that have each of the labels you specify.

Sample workflow snippet:
```
  metadata:
    plugin: quay.io/arcalot/arcaflow-plugin-metadata:latest
    deploy:
      type: kubernetes
      connection: !expr $.steps.kubeconfig.outputs.success.connection
      pod:
        metadata:
          namespace: default
          labels:
            arcaflow: metadata
        spec:
          pluginContainer:
            imagePullPolicy: Always
          nodeSelector:
            stress: "true"
    input: {}

```
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).