### PR TITLE
redefined labelValue regex validation

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.47
+          version: v1.52.2
           args: --timeout=3m
   test:
     name: go test

--- a/schema.go
+++ b/schema.go
@@ -1983,7 +1983,7 @@ var labelName = schema.NewStringSchema(
 var labelValue = schema.NewStringSchema(
 	nil,
 	schema.IntPointer(63),
-	regexp.MustCompile(`^(|[a-zA-Z0-9]+(|[-_.][a-zA-Z0-9]+)*[a-zA-Z0-9])$`),
+	regexp.MustCompile(`^$|^([a-zA-Z0-9]+[-._]*)+$`),
 )
 var dnsSubdomainName = schema.NewStringSchema(
 	nil,

--- a/schema_test.go
+++ b/schema_test.go
@@ -63,7 +63,7 @@ func TestLabelName(t *testing.T) {
 }
 
 func TestLabelValue(t *testing.T) {
-	for _, item := range []any{"", "kubernetes.io_test", "test"} {
+	for _, item := range []any{"", "kubernetes.io_test", "test-1-0"} {
 		t.Run(item.(string), func(t *testing.T) {
 			unserializedData, err := labelValue.Unserialize(item)
 			assert.NoError(t, err)


### PR DESCRIPTION
## Changes introduced with this PR

The previous labelValue regex prevents the use of legit kubernetes label values (eg. like `master-0` for a node selector). 
The proposed one accepts either an empty string or a string composed by any capital or lowercase letter or numbers separated by dash dot or underscore as stated by the kubernetes documentation https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ 

The following validation output has been reported by a kraken user that is using `kubernetes.io/hostname: master-0` as node selector:
```
Workflow execution failed (failed to unserialize deployer config for step stressng (Validation failed for 'pod' -> 'spec' -> 'nodeSelector' -> '[kubernetes.io/hostname]': String must match the pattern ^(|[a-zA-Z0-9]+(|[-_.][a-zA-Z0-9]+)*[a-zA-Z0-9])$))
```
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).