### PR TITLE
Fixed the private key regex

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -816,7 +816,7 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				},
 			),
 			"key": schema.NewPropertySchema(
-				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN ([A-Z]+) PRIVATE KEY-----(\s*.*\s*)*-----END ([A-Z]+) PRIVATE KEY-----\s*$`)),
+				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----(.|\n)+-----END(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----\s*$`)),
 				schema.NewDisplayValue(
 					schema.PointerTo("Client key"),
 					schema.PointerTo("Client private key in PEM format to authenticate against Kubernetes with."),


### PR DESCRIPTION
- The current regex prevents the usage of private keys in the format `-----BEGIN PRIVATE KEY-----` (Without the RSA or other keywords in the middle) `([A-Z]+)` is not optional. 
- The current key content regex is very aggressive from a computational perspective `(.|\n)+` peforms better (tested on regex101.com)