### PR TITLE
Fix build errors

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.52.2


### PR DESCRIPTION
## Changes introduced with this PR

Updating a few version to mimic ACT build CI seems to have fixed the issues.
Old build errors found [here](https://github.com/arcalot/arcaflow-engine-deployer-kubernetes/actions/runs/6473352887/job/17575862418?pr=23)
Tests for these fix can be found [here](https://github.com/jdowni000/arcaflow-engine-deployer-kubernetes/actions/runs/6483491605)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).