### PR TITLE
[CHAOS] Added support for insecure-skip-tls-verify

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,8 +35,9 @@ type Connection struct {
 
 	BearerToken string `json:"bearerToken,omitempty" yaml:"bearerToken,omitempty"`
 
-	QPS   float64 `json:"qps,omitempty" yaml:"qps,omitempty"`
-	Burst int64   `json:"burst,omitempty" yaml:"burst,omitempty"`
+	QPS      float64 `json:"qps,omitempty" yaml:"qps,omitempty"`
+	Burst    int64   `json:"burst,omitempty" yaml:"burst,omitempty"`
+	Insecure bool    `json:"insecure,omitempty" yaml:"insecure,omitempty"`
 }
 
 // Pod describes the pod to launch.

--- a/config.go
+++ b/config.go
@@ -29,9 +29,9 @@ type Connection struct {
 
 	ServerName string `json:"serverName,omitempty" yaml:"serverName,omitempty"`
 
-	CertData string `json:"cert,omitempty" yaml:"cert,omitempty"`
-	KeyData  string `json:"key,omitempty" yaml:"key,omitempty"`
-	CAData   string `json:"cacert,omitempty" yaml:"cacert,omitempty"`
+	CertData *string `json:"cert,omitempty" yaml:"cert,omitempty"`
+	KeyData  *string `json:"key,omitempty" yaml:"key,omitempty"`
+	CAData   *string `json:"cacert,omitempty" yaml:"cacert,omitempty"`
 
 	BearerToken string `json:"bearerToken,omitempty" yaml:"bearerToken,omitempty"`
 

--- a/connector.go
+++ b/connector.go
@@ -53,7 +53,9 @@ func (c connector) Deploy(ctx context.Context, image string) (deployer.Plugin, e
 	if meta.Name == "" && meta.GenerateName == "" {
 		meta.GenerateName = "arcaflow-plugin-"
 	}
-
+	if c.config.Connection.Insecure {
+		c.logger.Warningf("Deploying without TLS verification, do it at your own risk.")
+	}
 	c.logger.Infof("Deploying pod from image %s...", image)
 	pod, err := c.cli.CoreV1().Pods(c.config.Pod.Metadata.Namespace).Create(
 		ctx,

--- a/connector_test.go
+++ b/connector_test.go
@@ -118,6 +118,7 @@ func getConfigStruct(t *testing.T) kubernetes.Config {
 			Username:    kubeconfig.Username,
 			Password:    kubeconfig.Password,
 			ServerName:  kubeconfig.ServerName,
+			Insecure:    kubeconfig.Insecure,
 			CertData:    string(kubeconfig.CertData),
 			KeyData:     string(kubeconfig.KeyData),
 			CAData:      string(kubeconfig.CAData),

--- a/connector_test.go
+++ b/connector_test.go
@@ -111,6 +111,24 @@ func getConfigStruct(t *testing.T) kubernetes.Config {
 		t.Skipf("Skipping test, load kubeconfig file from user home directory (%v)", err)
 	}
 
+	var certData *string
+	var keyData *string
+	var caData *string
+	if kubeconfig.CertData != nil {
+		certDataStr := string(kubeconfig.CertData)
+		certData = &certDataStr
+	}
+
+	if kubeconfig.KeyData != nil {
+		keyDataStr := string(kubeconfig.KeyData)
+		keyData = &keyDataStr
+	}
+
+	if kubeconfig.CAData != nil {
+		caDataStr := string(kubeconfig.CAData)
+		caData = &caDataStr
+	}
+
 	configStruct := kubernetes.Config{
 		Connection: kubernetes.Connection{
 			Host:        kubeconfig.Host,
@@ -119,9 +137,9 @@ func getConfigStruct(t *testing.T) kubernetes.Config {
 			Password:    kubeconfig.Password,
 			ServerName:  kubeconfig.ServerName,
 			Insecure:    kubeconfig.Insecure,
-			CertData:    string(kubeconfig.CertData),
-			KeyData:     string(kubeconfig.KeyData),
-			CAData:      string(kubeconfig.CAData),
+			CertData:    certData,
+			KeyData:     keyData,
+			CAData:      caData,
 			BearerToken: kubeconfig.BearerToken,
 			QPS:         float64(kubeconfig.QPS),
 			Burst:       int64(kubeconfig.Burst),

--- a/factory.go
+++ b/factory.go
@@ -55,6 +55,18 @@ func (f factory) Create(config *Config, logger log.Logger) (deployer.Connector, 
 }
 
 func (f factory) createConnectionConfig(config *Config) restclient.Config {
+	caData := []byte("")
+	keyData := []byte("")
+	certData := []byte("")
+	if config.Connection.CAData != nil {
+		caData = []byte(*config.Connection.CAData)
+	}
+	if config.Connection.KeyData != nil {
+		keyData = []byte(*config.Connection.KeyData)
+	}
+	if config.Connection.CertData != nil {
+		certData = []byte(*config.Connection.CertData)
+	}
 	return restclient.Config{
 		Host:    config.Connection.Host,
 		APIPath: config.Connection.APIPath,
@@ -68,9 +80,9 @@ func (f factory) createConnectionConfig(config *Config) restclient.Config {
 		Impersonate: restclient.ImpersonationConfig{},
 		TLSClientConfig: restclient.TLSClientConfig{
 			ServerName: config.Connection.ServerName,
-			CertData:   []byte(config.Connection.CertData),
-			KeyData:    []byte(config.Connection.KeyData),
-			CAData:     []byte(config.Connection.CAData),
+			CertData:   certData,
+			KeyData:    keyData,
+			CAData:     caData,
 			Insecure:   config.Connection.Insecure,
 		},
 		UserAgent: "Arcaflow",

--- a/factory.go
+++ b/factory.go
@@ -71,6 +71,7 @@ func (f factory) createConnectionConfig(config *Config) restclient.Config {
 			CertData:   []byte(config.Connection.CertData),
 			KeyData:    []byte(config.Connection.KeyData),
 			CAData:     []byte(config.Connection.CAData),
+			Insecure:   config.Connection.Insecure,
 		},
 		UserAgent: "Arcaflow",
 		QPS:       float32(config.Connection.QPS),

--- a/schema.go
+++ b/schema.go
@@ -1007,7 +1007,7 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				nil,
 			),
 			"cacert": schema.NewPropertySchema(
-				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
+				schema.NewStringSchema(schema.IntPointer(0), nil, regexp.MustCompile(`^|\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
 				schema.NewDisplayValue(
 					schema.PointerTo("CA certificate"),
 					schema.PointerTo("CA certificate in PEM format to verify Kubernetes server certificate against."),
@@ -1023,7 +1023,7 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				},
 			),
 			"cert": schema.NewPropertySchema(
-				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
+				schema.NewStringSchema(schema.IntPointer(0), nil, regexp.MustCompile(`^|\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
 				schema.NewDisplayValue(
 					schema.PointerTo("Client certificate"),
 					schema.PointerTo("Client certificate in PEM format to authenticate against Kubernetes with."),
@@ -1039,7 +1039,7 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				},
 			),
 			"key": schema.NewPropertySchema(
-				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----(.|\n)+-----END(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----\s*$`)),
+				schema.NewStringSchema(schema.IntPointer(0), nil, regexp.MustCompile(`^|\s*-----BEGIN(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----(.|\n)+-----END(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----\s*$`)),
 				schema.NewDisplayValue(
 					schema.PointerTo("Client key"),
 					schema.PointerTo("Client private key in PEM format to authenticate against Kubernetes with."),
@@ -1102,6 +1102,20 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				nil,
 				nil,
 				schema.PointerTo(`10`),
+				nil,
+			).TreatEmptyAsDefaultValue(),
+			"insecure": schema.NewPropertySchema(
+				schema.NewBoolSchema(),
+				schema.NewDisplayValue(
+					schema.PointerTo("Insecure Connection"),
+					schema.PointerTo("Skip TLS certificate validation"),
+					nil,
+				),
+				false,
+				nil,
+				nil,
+				nil,
+				nil,
 				nil,
 			).TreatEmptyAsDefaultValue(),
 		},

--- a/schema.go
+++ b/schema.go
@@ -1007,7 +1007,7 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				nil,
 			),
 			"cacert": schema.NewPropertySchema(
-				schema.NewStringSchema(schema.IntPointer(0), nil, regexp.MustCompile(`^|\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
+				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
 				schema.NewDisplayValue(
 					schema.PointerTo("CA certificate"),
 					schema.PointerTo("CA certificate in PEM format to verify Kubernetes server certificate against."),
@@ -1023,7 +1023,7 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				},
 			),
 			"cert": schema.NewPropertySchema(
-				schema.NewStringSchema(schema.IntPointer(0), nil, regexp.MustCompile(`^|\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
+				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN CERTIFICATE-----(.|\n)+-----END CERTIFICATE-----\s*$`)),
 				schema.NewDisplayValue(
 					schema.PointerTo("Client certificate"),
 					schema.PointerTo("Client certificate in PEM format to authenticate against Kubernetes with."),
@@ -1039,7 +1039,7 @@ var Schema = schema.NewTypedScopeSchema[*Config](
 				},
 			),
 			"key": schema.NewPropertySchema(
-				schema.NewStringSchema(schema.IntPointer(0), nil, regexp.MustCompile(`^|\s*-----BEGIN(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----(.|\n)+-----END(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----\s*$`)),
+				schema.NewStringSchema(schema.IntPointer(1), nil, regexp.MustCompile(`^\s*-----BEGIN(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----(.|\n)+-----END(\s+[A-Z]+\s+|\s+)PRIVATE KEY-----\s*$`)),
 				schema.NewDisplayValue(
 					schema.PointerTo("Client key"),
 					schema.PointerTo("Client private key in PEM format to authenticate against Kubernetes with."),


### PR DESCRIPTION
## Changes introduced with this PR

Enable support to run functional tests on the arcaflow integration in KRKN on insecure clusters (when enabled in the deployer config).
Even if this may seem a bad practice, it will enable arcaflow engine to be used in development and testing scenarios that currently are unsupported.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).