### PR TITLE
Update workflow to pass Go version to go-lint-and-test subworkflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,3 +8,5 @@ jobs:
   lint_and_test:
     name: lint and test
     uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@main
+    with:
+      go_version: ${{ vars.ARCALOT_GO_VERSION }}


### PR DESCRIPTION
## Changes introduced with this PR

Now that the Go lint-and-test reusable workflow requires the Go version as an input (see https://github.com/arcalot/arcaflow-reusable-workflows/pull/18), the workflow for this repo needs to be updated.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).